### PR TITLE
Add project skeleton and pytest setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "xiangqi-core"
+version = "1.0.0"
+description = "Core rules engine for Xiangqi (Chinese Chess) v1.0.0"
+requires-python = ">=3.10"
+authors = [{ name = "Xiangqi Coach Team" }]
+readme = "README.md"
+license = { text = "MIT" }
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/xiangqi_core/__init__.py
+++ b/src/xiangqi_core/__init__.py
@@ -1,0 +1,7 @@
+"""
+Core package for Xiangqi rules engine v1.0.0.
+
+This package will house rule definitions, validations, and supporting utilities.
+"""
+
+__all__ = []

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,4 @@
+def test_package_import():
+    import xiangqi_core
+
+    assert hasattr(xiangqi_core, "__all__")


### PR DESCRIPTION
## Summary
- establish the src/xiangqi_core package to hold the v1.0.0 rules engine
- configure pyproject.toml with build metadata and pytest defaults for the src layout
- add a smoke test for package importability and ignore cache artifacts

## Linked Issue
- Closes #1

## Changes
- [x] Core logic changes
- [x] Tests added/updated
- [ ] Docs updated (if needed)

## How to Test
```bash
pytest -q
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694eac04f80883249e3782b92160b3e8)