### PR TITLE
Add board coordinates and basic piece structures

### DIFF
--- a/src/xiangqi_core/__init__.py
+++ b/src/xiangqi_core/__init__.py
@@ -1,7 +1,30 @@
-"""
-Core package for Xiangqi rules engine v1.0.0.
+"""Core package for Xiangqi rules engine v1.0.0."""
 
-This package will house rule definitions, validations, and supporting utilities.
-"""
+from xiangqi_core.board import Board, Position, initial_position
+from xiangqi_core.coord import Coord
+from xiangqi_core.errors import (
+    GameOverError,
+    IllegalMoveError,
+    ParseCoordError,
+    ParseMoveError,
+    XiangqiError,
+)
+from xiangqi_core.move import Move
+from xiangqi_core.piece import Piece
+from xiangqi_core.types import PieceType, Side
 
-__all__ = []
+__all__ = [
+    "Board",
+    "Coord",
+    "GameOverError",
+    "IllegalMoveError",
+    "Move",
+    "ParseCoordError",
+    "ParseMoveError",
+    "Piece",
+    "PieceType",
+    "Position",
+    "Side",
+    "XiangqiError",
+    "initial_position",
+]

--- a/src/xiangqi_core/board.py
+++ b/src/xiangqi_core/board.py
@@ -1,0 +1,115 @@
+"""Board and position structures for Xiangqi."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, Mapping, Optional, Tuple
+
+from xiangqi_core.coord import Coord
+from xiangqi_core.errors import IllegalMoveError
+from xiangqi_core.move import Move
+from xiangqi_core.piece import Piece
+from xiangqi_core.types import PieceType, Side
+
+
+class Board:
+    """Sparse board representation backed by a dictionary."""
+
+    def __init__(self, pieces: Optional[Mapping[Coord, Piece]] = None) -> None:
+        self._grid: Dict[Coord, Piece] = {}
+        if pieces:
+            for coord, piece in pieces.items():
+                self._validate_coord(coord)
+                self._grid[coord] = piece
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._grid)
+
+    def __iter__(self) -> Iterator[Tuple[Coord, Piece]]:  # pragma: no cover
+        return iter(self._grid.items())
+
+    @staticmethod
+    def _validate_coord(coord: Coord) -> None:
+        if not isinstance(coord, Coord):
+            raise TypeError("Board keys must be Coord instances")
+        if not coord.in_bounds():
+            raise ValueError(f"Coordinate out of bounds: {coord}")
+
+    def get(self, coord: Coord) -> Optional[Piece]:
+        """Return the piece at ``coord`` or ``None`` if empty."""
+
+        self._validate_coord(coord)
+        return self._grid.get(coord)
+
+    def place(self, coord: Coord, piece: Piece) -> None:
+        """Place ``piece`` on ``coord`` (overwriting any existing piece)."""
+
+        self._validate_coord(coord)
+        self._grid[coord] = piece
+
+    def remove(self, coord: Coord) -> Optional[Piece]:
+        """Remove and return the piece at ``coord`` if present."""
+
+        self._validate_coord(coord)
+        return self._grid.pop(coord, None)
+
+    def move_piece(self, move: Move) -> Optional[Piece]:
+        """Execute ``move`` on the board and return any captured piece."""
+
+        self._validate_coord(move.frm)
+        self._validate_coord(move.to)
+        piece = self._grid.get(move.frm)
+        if piece is None:
+            raise IllegalMoveError(f"No piece at source square {move.frm}")
+        captured = self._grid.get(move.to)
+        self._grid.pop(move.frm)
+        self._grid[move.to] = piece
+        return captured
+
+    def items(self) -> Iterable[Tuple[Coord, Piece]]:  # pragma: no cover
+        return self._grid.items()
+
+
+@dataclass
+class Position:
+    board: Board
+    side_to_move: Side
+
+
+def initial_position() -> Position:
+    """Return the standard Xiangqi starting position."""
+
+    board = Board()
+
+    def _place_back_rank(side: Side, y: int) -> None:
+        pieces = [
+            PieceType.ROOK,
+            PieceType.HORSE,
+            PieceType.ELEPHANT,
+            PieceType.ADVISOR,
+            PieceType.KING,
+            PieceType.ADVISOR,
+            PieceType.ELEPHANT,
+            PieceType.HORSE,
+            PieceType.ROOK,
+        ]
+        for x, piece_type in enumerate(pieces):
+            board.place(Coord(x, y), Piece(side=side, type=piece_type))
+
+    def _place_cannons(side: Side, y: int) -> None:
+        for x in (1, 7):
+            board.place(Coord(x, y), Piece(side=side, type=PieceType.CANNON))
+
+    def _place_pawns(side: Side, y: int) -> None:
+        for x in (0, 2, 4, 6, 8):
+            board.place(Coord(x, y), Piece(side=side, type=PieceType.PAWN))
+
+    _place_back_rank(Side.RED, 0)
+    _place_cannons(Side.RED, 2)
+    _place_pawns(Side.RED, 3)
+
+    _place_back_rank(Side.BLACK, 9)
+    _place_cannons(Side.BLACK, 7)
+    _place_pawns(Side.BLACK, 6)
+
+    return Position(board=board, side_to_move=Side.RED)

--- a/src/xiangqi_core/coord.py
+++ b/src/xiangqi_core/coord.py
@@ -1,0 +1,55 @@
+"""Coordinate utilities for the Xiangqi board (9 columns x 10 rows)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from xiangqi_core.errors import ParseCoordError
+
+_FILE_TO_INDEX = {char: idx for idx, char in enumerate("abcdefghi")}
+_INDEX_TO_FILE = "abcdefghi"
+
+
+@dataclass(frozen=True, slots=True)
+class Coord:
+    """Immutable board coordinate using 0-based indexing."""
+
+    x: int
+    y: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.x, int) or not isinstance(self.y, int):
+            raise TypeError("Coord coordinates must be integers")
+
+    def to_str(self) -> str:
+        """Return ICCS-style string representation (e.g., ``\"e2\"``)."""
+
+        if not self.in_bounds():
+            raise ValueError(f"Coordinate out of bounds: {self}")
+        return f"{_INDEX_TO_FILE[self.x]}{self.y}"
+
+    def in_bounds(self) -> bool:
+        """Return ``True`` if the coordinate lies on a 9x10 board."""
+
+        return 0 <= self.x <= 8 and 0 <= self.y <= 9
+
+    @classmethod
+    def from_str(cls, value: str) -> "Coord":
+        """Parse a coordinate from a string like ``\"a0\"`` or ``\"i9\"``."""
+
+        if not isinstance(value, str):
+            raise ParseCoordError("Coordinate must be a string")
+        normalized = value.strip().lower()
+        if len(normalized) != 2:
+            raise ParseCoordError(f"Invalid coordinate format: {value}")
+        file_char, rank_char = normalized[0], normalized[1]
+        if file_char not in _FILE_TO_INDEX:
+            raise ParseCoordError(f"Invalid file in coordinate: {value}")
+        if not rank_char.isdigit():
+            raise ParseCoordError(f"Invalid rank in coordinate: {value}")
+        x = _FILE_TO_INDEX[file_char]
+        y = int(rank_char)
+        coord = cls(x=x, y=y)
+        if not coord.in_bounds():
+            raise ParseCoordError(f"Coordinate out of bounds: {value}")
+        return coord

--- a/src/xiangqi_core/errors.py
+++ b/src/xiangqi_core/errors.py
@@ -1,0 +1,21 @@
+"""Domain-specific exception types used across the Xiangqi core package."""
+
+
+class XiangqiError(Exception):
+    """Base class for Xiangqi-specific errors."""
+
+
+class ParseCoordError(ValueError, XiangqiError):
+    """Raised when a coordinate string cannot be parsed."""
+
+
+class ParseMoveError(ValueError, XiangqiError):
+    """Raised when a move string cannot be parsed."""
+
+
+class IllegalMoveError(ValueError, XiangqiError):
+    """Raised when a move violates Xiangqi rules."""
+
+
+class GameOverError(RuntimeError, XiangqiError):
+    """Raised when attempting to play a move after the game is finished."""

--- a/src/xiangqi_core/move.py
+++ b/src/xiangqi_core/move.py
@@ -1,0 +1,19 @@
+"""Move representation for Xiangqi."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from xiangqi_core.coord import Coord
+
+
+@dataclass(frozen=True, slots=True)
+class Move:
+    """Represents a move from one coordinate to another."""
+
+    frm: Coord
+    to: Coord
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.frm, Coord) or not isinstance(self.to, Coord):
+            raise TypeError("Move endpoints must be Coord instances")

--- a/src/xiangqi_core/piece.py
+++ b/src/xiangqi_core/piece.py
@@ -1,0 +1,18 @@
+"""Piece definitions for Xiangqi."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from xiangqi_core.types import PieceType, Side
+
+
+@dataclass(frozen=True, slots=True)
+class Piece:
+    """Immutable representation of a Xiangqi piece without board position."""
+
+    side: Side
+    type: PieceType
+
+    def __str__(self) -> str:
+        return f"{self.side.value}:{self.type.value}"

--- a/src/xiangqi_core/types.py
+++ b/src/xiangqi_core/types.py
@@ -1,0 +1,65 @@
+"""Common enumerations used across the Xiangqi rules engine.
+
+The enums defined here are intentionally small and opinionated to keep
+the rest of the codebase type-safe and readable.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Side(str, Enum):
+    """Represents the side of a piece or player.
+
+    The values are lowercase strings to make serialization straightforward.
+    """
+
+    RED = "red"
+    BLACK = "black"
+
+    def opponent(self) -> "Side":
+        """Return the opposing side.
+
+        Examples
+        --------
+        >>> Side.RED.opponent()
+        <Side.BLACK: 'black'>
+        >>> Side.BLACK.opponent()
+        <Side.RED: 'red'>
+        """
+
+        return Side.BLACK if self is Side.RED else Side.RED
+
+    @classmethod
+    def from_str(cls, value: str) -> "Side":
+        """Parse a ``Side`` value from a string.
+
+        Parameters
+        ----------
+        value:
+            Any case-insensitive representation of ``"red"`` or ``"black"``.
+
+        Raises
+        ------
+        ValueError
+            If ``value`` does not correspond to a known side.
+        """
+
+        normalized = value.strip().lower()
+        try:
+            return cls(normalized)
+        except ValueError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Invalid side: {value}") from exc
+
+
+class PieceType(str, Enum):
+    """Enumerates the seven distinct Xiangqi piece types."""
+
+    KING = "king"
+    ADVISOR = "advisor"
+    ELEPHANT = "elephant"
+    HORSE = "horse"
+    ROOK = "rook"
+    CANNON = "cannon"
+    PAWN = "pawn"

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,58 @@
+import pytest
+
+from xiangqi_core import (
+    Board,
+    Coord,
+    IllegalMoveError,
+    Move,
+    Piece,
+    PieceType,
+    Side,
+    initial_position,
+)
+
+
+def test_initial_position_piece_layout():
+    position = initial_position()
+    board = position.board
+
+    assert position.side_to_move is Side.RED
+    assert len(list(board.items())) == 32
+
+    # Red back rank
+    assert board.get(Coord.from_str("a0")).type is PieceType.ROOK
+    assert board.get(Coord.from_str("e0")).type is PieceType.KING
+    assert board.get(Coord.from_str("h0")).type is PieceType.HORSE
+
+    # Black back rank
+    assert board.get(Coord.from_str("e9")).side is Side.BLACK
+    assert board.get(Coord.from_str("i9")).type is PieceType.ROOK
+
+    # Cannons and pawns
+    assert board.get(Coord.from_str("b2")).type is PieceType.CANNON
+    assert board.get(Coord.from_str("h7")).side is Side.BLACK
+    assert board.get(Coord.from_str("c3")).type is PieceType.PAWN
+    assert board.get(Coord.from_str("i6")).side is Side.BLACK
+
+
+def test_move_piece_and_capture():
+    board = Board({Coord(0, 0): Piece(Side.RED, PieceType.ROOK)})
+    move = Move(Coord(0, 0), Coord(0, 5))
+    captured = board.move_piece(move)
+    assert captured is None
+    assert board.get(Coord(0, 5)).type is PieceType.ROOK
+    assert board.get(Coord(0, 0)) is None
+
+    # Add an opposing piece to capture
+    board.place(Coord(1, 5), Piece(Side.BLACK, PieceType.PAWN))
+    capture_move = Move(Coord(0, 5), Coord(1, 5))
+    captured_piece = board.move_piece(capture_move)
+    assert captured_piece is not None
+    assert captured_piece.side is Side.BLACK
+    assert board.get(Coord(1, 5)).type is PieceType.ROOK
+
+
+def test_move_from_empty_square_raises():
+    board = Board()
+    with pytest.raises(IllegalMoveError):
+        board.move_piece(Move(Coord(0, 0), Coord(0, 1)))

--- a/tests/test_coord.py
+++ b/tests/test_coord.py
@@ -1,0 +1,27 @@
+import pytest
+
+from xiangqi_core import Coord, ParseCoordError
+
+
+def test_coord_to_and_from_str_round_trip():
+    coord = Coord.from_str("e2")
+    assert coord.to_str() == "e2"
+    assert coord.in_bounds()
+
+
+@pytest.mark.parametrize("text", ["a0", "i9", "C5", " h7 "])
+def test_coord_from_str_valid_inputs(text):
+    coord = Coord.from_str(text)
+    assert coord.in_bounds()
+    assert coord.to_str() == coord.to_str().lower()
+
+
+@pytest.mark.parametrize("text", ["", "j0", "a10", "aa0", "b", "9c", "a-1"])
+def test_coord_from_str_invalid_inputs(text):
+    with pytest.raises(ParseCoordError):
+        Coord.from_str(text)
+
+
+def test_coord_out_of_bounds_to_str_raises():
+    with pytest.raises(ValueError):
+        Coord(9, 0).to_str()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,38 @@
+import pytest
+
+from xiangqi_core import PieceType, Side
+
+
+def test_side_opponent_round_trip():
+    assert Side.RED.opponent() is Side.BLACK
+    assert Side.BLACK.opponent() is Side.RED
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("red", Side.RED),
+        ("RED", Side.RED),
+        (" Red  ", Side.RED),
+        ("black", Side.BLACK),
+        ("BLACK", Side.BLACK),
+        (" Black  ", Side.BLACK),
+    ],
+)
+def test_side_from_str_valid(value, expected):
+    assert Side.from_str(value) is expected
+
+
+def test_side_from_str_invalid():
+    with pytest.raises(ValueError):
+        Side.from_str("blue")
+
+
+def test_piece_types_are_string_enums():
+    assert PieceType.KING.value == "king"
+    assert PieceType.PAWN.value == "pawn"
+
+
+def test_all_exported():
+    assert "Side" in __import__("xiangqi_core").__all__
+    assert "PieceType" in __import__("xiangqi_core").__all__


### PR DESCRIPTION
## Summary
- Add enums for sides and piece types with simple string values and helper parsing
- Export enums from the package interface for downstream use
- Cover side parsing and enum values with unit tests
- Implement coordinate parsing/formatting utilities and board/position structures with initial setup
- Provide core piece, move, and error types plus tests for coordinates and board movement

## Linked Issue
- Closes #3
- Closes #4
- Closes #5
- Closes #6
- Closes #7
- Closes #8
- Closes #9
- Closes #10

## Changes
- [x] Core logic changes
- [x] Tests added/updated
- [ ] Docs updated (if needed)

## How to Test
```bash
pytest -q
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694fba7d27f08324871ac17b51270426)