### PR TITLE
Add move string parsing utilities

### DIFF
--- a/src/xiangqi_core/move.py
+++ b/src/xiangqi_core/move.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from xiangqi_core.coord import Coord
+from xiangqi_core.errors import ParseCoordError, ParseMoveError
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,3 +18,27 @@ class Move:
     def __post_init__(self) -> None:
         if not isinstance(self.frm, Coord) or not isinstance(self.to, Coord):
             raise TypeError("Move endpoints must be Coord instances")
+
+    def to_str(self) -> str:
+        """Return a compact string representation like ``\"a0b3\"``."""
+
+        return f"{self.frm.to_str()}{self.to.to_str()}"
+
+    @classmethod
+    def from_str(cls, value: str) -> "Move":
+        """Parse a ``Move`` from a string containing two coordinates."""
+
+        if not isinstance(value, str):
+            raise ParseMoveError("Move must be a string")
+
+        normalized = value.strip().lower()
+        if len(normalized) != 4:
+            raise ParseMoveError(f"Invalid move format: {value}")
+
+        try:
+            frm = Coord.from_str(normalized[:2])
+            to = Coord.from_str(normalized[2:])
+        except ParseCoordError as exc:
+            raise ParseMoveError(f"Invalid move coordinates: {value}") from exc
+
+        return cls(frm=frm, to=to)

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -1,0 +1,21 @@
+import pytest
+
+from xiangqi_core import Coord, Move, ParseMoveError
+
+
+def test_move_from_str_and_to_str_round_trip():
+    move = Move.from_str("a0b3")
+    assert move.frm == Coord.from_str("a0")
+    assert move.to == Coord.from_str("b3")
+    assert move.to_str() == "a0b3"
+
+
+@pytest.mark.parametrize("text", ["", "a0", "a0b", "a0b10", "k0a1", "a-1b0"])
+def test_move_from_str_invalid_inputs(text):
+    with pytest.raises(ParseMoveError):
+        Move.from_str(text)
+
+
+def test_move_from_str_rejects_non_string():
+    with pytest.raises(ParseMoveError):
+        Move.from_str(123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add `Move.to_str` and `Move.from_str` helpers for compact move serialization
- validate move parsing with new unit tests

## Linked Issue
- Closes #10

## Changes
- [x] Core logic changes
- [x] Tests added/updated
- [ ] Docs updated (if needed)

## How to Test
```bash
pytest
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694fc73d2ff08324b6dc3d772b7037b1)