### PR TITLE
Implement move legality and game state logic

### DIFF
--- a/src/xiangqi_core/__init__.py
+++ b/src/xiangqi_core/__init__.py
@@ -1,6 +1,7 @@
 """Core package for Xiangqi rules engine v1.0.0."""
 
 from xiangqi_core.board import Board, Position, initial_position
+from xiangqi_core.attack import find_king, is_in_check, is_square_attacked
 from xiangqi_core.coord import Coord
 from xiangqi_core.errors import (
     GameOverError,
@@ -9,15 +10,27 @@ from xiangqi_core.errors import (
     ParseMoveError,
     XiangqiError,
 )
+from xiangqi_core.game import Game, GameResult
+from xiangqi_core.legality import generate_legal_moves, is_checkmate, is_legal_move
 from xiangqi_core.move import Move
 from xiangqi_core.piece import Piece
 from xiangqi_core.types import PieceType, Side
+from xiangqi_core.rules import is_pseudo_legal_move
 
 __all__ = [
+    "Game",
+    "GameResult",
     "Board",
     "Coord",
     "GameOverError",
+    "generate_legal_moves",
+    "find_king",
     "IllegalMoveError",
+    "is_checkmate",
+    "is_in_check",
+    "is_legal_move",
+    "is_pseudo_legal_move",
+    "is_square_attacked",
     "Move",
     "ParseCoordError",
     "ParseMoveError",

--- a/src/xiangqi_core/attack.py
+++ b/src/xiangqi_core/attack.py
@@ -1,0 +1,47 @@
+"""Attack and check detection utilities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from xiangqi_core.board import Position
+from xiangqi_core.coord import Coord
+from xiangqi_core.move import Move
+from xiangqi_core.rules import _count_blockers, is_pseudo_legal_move
+from xiangqi_core.types import PieceType, Side
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from xiangqi_core.game import Game
+
+
+def find_king(position: Position, side: Side) -> Coord:
+    """Return the coordinate of ``side``'s king."""
+
+    for coord, piece in position.board:
+        if piece.type is PieceType.KING and piece.side is side:
+            return coord
+    raise ValueError(f"No king found for side {side}")
+
+
+def is_square_attacked(position: Position, by_side: Side, square: Coord) -> bool:
+    """Return ``True`` if any piece of ``by_side`` attacks ``square``."""
+
+    for coord, piece in position.board:
+        if piece.side is not by_side:
+            continue
+
+        if piece.type is PieceType.KING and coord.x == square.x:
+            if _count_blockers(position.board, coord, square) == 0:
+                return True
+
+        if is_pseudo_legal_move(position, Move(coord, square)):
+            return True
+
+    return False
+
+
+def is_in_check(position: Position, side: Side) -> bool:
+    """Return ``True`` if ``side``'s king is under attack."""
+
+    king_square = find_king(position, side)
+    return is_square_attacked(position, side.opponent(), king_square)

--- a/src/xiangqi_core/game.py
+++ b/src/xiangqi_core/game.py
@@ -1,0 +1,51 @@
+"""Game state machine coordinating move application and results."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+
+from xiangqi_core.board import Position, initial_position
+from xiangqi_core.errors import GameOverError, IllegalMoveError
+from xiangqi_core.legality import generate_legal_moves, is_checkmate, is_legal_move
+from xiangqi_core.move import Move
+from xiangqi_core.types import Side
+
+
+class GameResult(str, Enum):
+    """Represents the end state of a game."""
+
+    ONGOING = "ongoing"
+    RED_WIN = "red_win"
+    BLACK_WIN = "black_win"
+
+
+class Game:
+    """Encapsulates an in-progress Xiangqi game."""
+
+    def __init__(self, position: Optional[Position] = None) -> None:
+        self.position: Position = position or initial_position()
+        self.history: List[Move] = []
+        self.result: GameResult = GameResult.ONGOING
+
+    def apply_move(self, move: Move) -> None:
+        """Apply ``move`` if legal, updating game state and result."""
+
+        if self.result is not GameResult.ONGOING:
+            raise GameOverError("Game is already finished")
+
+        if not is_legal_move(self, move):
+            raise IllegalMoveError(f"Illegal move: {move.to_str()}")
+
+        self.position.board.move_piece(move)
+        self.history.append(move)
+        self.position.side_to_move = self.position.side_to_move.opponent()
+
+        opponent = self.position.side_to_move
+        if is_checkmate(self.position, opponent):
+            self.result = GameResult.RED_WIN if opponent is Side.BLACK else GameResult.BLACK_WIN
+
+    def legal_moves(self) -> List[Move]:
+        """Convenience wrapper for legal move generation for the side to move."""
+
+        return generate_legal_moves(self.position, self.position.side_to_move)

--- a/src/xiangqi_core/legality.py
+++ b/src/xiangqi_core/legality.py
@@ -1,0 +1,67 @@
+"""Full move legality checks including king safety."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from xiangqi_core.attack import is_in_check
+from xiangqi_core.board import Board, Position
+from xiangqi_core.coord import Coord
+from xiangqi_core.move import Move
+from xiangqi_core.rules import is_pseudo_legal_move
+from xiangqi_core.types import Side
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from xiangqi_core.game import Game
+
+
+def is_legal_move(game: "Game", move: Move) -> bool:
+    """Return ``True`` if ``move`` is legal in ``game``'s current position."""
+
+    position = game.position
+    piece = position.board.get(move.frm)
+    if piece is None or piece.side is not position.side_to_move:
+        return False
+
+    if not is_pseudo_legal_move(position, move):
+        return False
+
+    next_position = _apply_move(position, move)
+    return not is_in_check(next_position, piece.side)
+
+
+def generate_legal_moves(position: Position, side: Side) -> List[Move]:
+    """Enumerate all legal moves for ``side`` in ``position``."""
+
+    legal_moves: List[Move] = []
+    for coord, piece in position.board:
+        if piece.side is not side:
+            continue
+        for x in range(9):
+            for y in range(10):
+                dest = Coord(x, y)
+                move = Move(coord, dest)
+                if not is_pseudo_legal_move(position, move):
+                    continue
+                next_position = _apply_move(position, move, next_to_move=side.opponent())
+                if is_in_check(next_position, side):
+                    continue
+                legal_moves.append(move)
+    return legal_moves
+
+
+def is_checkmate(position: Position, side: Side) -> bool:
+    """Return ``True`` if ``side`` is checkmated."""
+
+    if not is_in_check(position, side):
+        return False
+    return len(generate_legal_moves(position, side)) == 0
+
+
+def _apply_move(position: Position, move: Move, next_to_move: Side | None = None) -> Position:
+    """Return a new ``Position`` representing ``move`` applied to ``position``."""
+
+    board_copy = Board({coord: piece for coord, piece in position.board})
+    board_copy.move_piece(move)
+    side_to_move = next_to_move if next_to_move is not None else position.side_to_move.opponent()
+    return Position(board=board_copy, side_to_move=side_to_move)

--- a/src/xiangqi_core/rules.py
+++ b/src/xiangqi_core/rules.py
@@ -1,0 +1,147 @@
+"""Pseudo-legal move validation for Xiangqi pieces."""
+
+from __future__ import annotations
+
+from xiangqi_core.board import Board, Position
+from xiangqi_core.coord import Coord
+from xiangqi_core.move import Move
+from xiangqi_core.types import PieceType, Side
+
+
+def is_pseudo_legal_move(position: Position, move: Move) -> bool:
+    """Return ``True`` if ``move`` satisfies piece geometry and blocking rules.
+
+    This function intentionally ignores turn order and king safety. It only
+    validates that the moving piece could travel from ``move.frm`` to
+    ``move.to`` according to Xiangqi movement rules and blocking constraints.
+    """
+
+    piece = position.board.get(move.frm)
+    if piece is None:
+        return False
+    if move.frm == move.to or not move.to.in_bounds():
+        return False
+
+    target_piece = position.board.get(move.to)
+    if target_piece is not None and target_piece.side is piece.side:
+        return False
+
+    if piece.type is PieceType.ROOK:
+        return _is_rook_move(position, move)
+    if piece.type is PieceType.CANNON:
+        return _is_cannon_move(position, move)
+    if piece.type is PieceType.HORSE:
+        return _is_horse_move(position, move)
+    if piece.type is PieceType.ELEPHANT:
+        return _is_elephant_move(position, move, piece.side)
+    if piece.type is PieceType.ADVISOR:
+        return _is_advisor_move(position, move, piece.side)
+    if piece.type is PieceType.KING:
+        return _is_king_move(position, move, piece.side)
+    if piece.type is PieceType.PAWN:
+        return _is_pawn_move(move, piece.side)
+
+    return False
+
+
+def _is_rook_move(position: Position, move: Move) -> bool:
+    if not _is_orthogonal(move):
+        return False
+    return _count_blockers(position.board, move.frm, move.to) == 0
+
+
+def _is_cannon_move(position: Position, move: Move) -> bool:
+    if not _is_orthogonal(move):
+        return False
+
+    blockers = _count_blockers(position.board, move.frm, move.to)
+    target_piece = position.board.get(move.to)
+    if target_piece is None:
+        return blockers == 0
+    return blockers == 1
+
+
+def _is_horse_move(position: Position, move: Move) -> bool:
+    dx = move.to.x - move.frm.x
+    dy = move.to.y - move.frm.y
+    if (abs(dx), abs(dy)) not in {(1, 2), (2, 1)}:
+        return False
+
+    if abs(dx) == 2:
+        block_square = Coord(move.frm.x + dx // 2, move.frm.y)
+    else:
+        block_square = Coord(move.frm.x, move.frm.y + dy // 2)
+
+    return position.board.get(block_square) is None
+
+
+def _is_elephant_move(position: Position, move: Move, side: Side) -> bool:
+    dx = move.to.x - move.frm.x
+    dy = move.to.y - move.frm.y
+    if abs(dx) != 2 or abs(dy) != 2:
+        return False
+
+    if side is Side.RED and move.to.y > 4:
+        return False
+    if side is Side.BLACK and move.to.y < 5:
+        return False
+
+    block_square = Coord(move.frm.x + dx // 2, move.frm.y + dy // 2)
+    return position.board.get(block_square) is None
+
+
+def _is_advisor_move(position: Position, move: Move, side: Side) -> bool:
+    dx = abs(move.to.x - move.frm.x)
+    dy = abs(move.to.y - move.frm.y)
+    if dx != 1 or dy != 1:
+        return False
+    return _in_palace(move.to, side)
+
+
+def _is_king_move(position: Position, move: Move, side: Side) -> bool:
+    dx = abs(move.to.x - move.frm.x)
+    dy = abs(move.to.y - move.frm.y)
+    if dx + dy != 1:
+        return False
+    return _in_palace(move.to, side)
+
+
+def _is_pawn_move(move: Move, side: Side) -> bool:
+    dx = move.to.x - move.frm.x
+    dy = move.to.y - move.frm.y
+    forward = 1 if side is Side.RED else -1
+    crossed_river = move.frm.y >= 5 if side is Side.RED else move.frm.y <= 4
+
+    if dx == 0 and dy == forward:
+        return True
+    if crossed_river and abs(dx) == 1 and dy == 0:
+        return True
+    return False
+
+
+def _count_blockers(board: Board, start: Coord, end: Coord) -> int:
+    """Return number of pieces strictly between ``start`` and ``end``."""
+
+    dx = end.x - start.x
+    dy = end.y - start.y
+    step_x = (dx > 0) - (dx < 0)
+    step_y = (dy > 0) - (dy < 0)
+
+    x, y = start.x + step_x, start.y + step_y
+    blockers = 0
+    while (x, y) != (end.x, end.y):
+        if board.get(Coord(x, y)) is not None:
+            blockers += 1
+        x += step_x
+        y += step_y
+    return blockers
+
+
+def _is_orthogonal(move: Move) -> bool:
+    return move.frm.x == move.to.x or move.frm.y == move.to.y
+
+
+def _in_palace(coord: Coord, side: Side) -> bool:
+    if side is Side.RED:
+        return 3 <= coord.x <= 5 and 0 <= coord.y <= 2
+    return 3 <= coord.x <= 5 and 7 <= coord.y <= 9

--- a/tests/test_attack.py
+++ b/tests/test_attack.py
@@ -1,0 +1,62 @@
+from xiangqi_core import (
+    Board,
+    Coord,
+    Piece,
+    PieceType,
+    Position,
+    Side,
+    find_king,
+    is_in_check,
+    is_square_attacked,
+)
+
+
+def test_rook_and_cannon_attack_detection() -> None:
+    rook_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.ROOK),
+            Coord(0, 3): Piece(Side.BLACK, PieceType.KING),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.ROOK),
+            Coord(4, 1): Piece(Side.RED, PieceType.KING),
+        }
+    )
+    rook_pos = Position(board=rook_board, side_to_move=Side.RED)
+    assert is_square_attacked(rook_pos, Side.RED, Coord(0, 3))
+    assert is_in_check(rook_pos, Side.BLACK)
+
+    cannon_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.CANNON),
+            Coord(0, 1): Piece(Side.BLACK, PieceType.PAWN),
+            Coord(0, 3): Piece(Side.BLACK, PieceType.KING),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.ROOK),
+            Coord(4, 1): Piece(Side.RED, PieceType.KING),
+        }
+    )
+    cannon_pos = Position(board=cannon_board, side_to_move=Side.RED)
+    assert is_square_attacked(cannon_pos, Side.RED, Coord(0, 3))
+
+    no_screen_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.CANNON),
+            Coord(0, 3): Piece(Side.BLACK, PieceType.KING),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.ROOK),
+            Coord(4, 1): Piece(Side.RED, PieceType.KING),
+        }
+    )
+    no_screen_pos = Position(board=no_screen_board, side_to_move=Side.RED)
+    assert not is_square_attacked(no_screen_pos, Side.RED, Coord(0, 3))
+
+
+def test_face_to_face_kings_count_as_attack() -> None:
+    board = Board(
+        {
+            Coord(4, 1): Piece(Side.RED, PieceType.KING),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.KING),
+        }
+    )
+    position = Position(board=board, side_to_move=Side.RED)
+
+    assert is_in_check(position, Side.RED)
+    assert is_in_check(position, Side.BLACK)
+    assert find_king(position, Side.RED) == Coord(4, 1)

--- a/tests/test_legality.py
+++ b/tests/test_legality.py
@@ -1,0 +1,56 @@
+from xiangqi_core import (
+    Board,
+    Coord,
+    Game,
+    GameResult,
+    Move,
+    Piece,
+    PieceType,
+    Position,
+    Side,
+    generate_legal_moves,
+    is_checkmate,
+    is_legal_move,
+)
+
+
+def test_move_exposing_king_is_illegal() -> None:
+    board = Board(
+        {
+            Coord(4, 1): Piece(Side.RED, PieceType.KING),
+            Coord(4, 3): Piece(Side.RED, PieceType.ROOK),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.ROOK),
+            Coord(3, 9): Piece(Side.BLACK, PieceType.KING),
+        }
+    )
+    position = Position(board=board, side_to_move=Side.RED)
+    game = Game(position=position)
+
+    unsafe_move = Move(Coord(4, 3), Coord(3, 3))
+    assert not is_legal_move(game, unsafe_move)
+
+    safe_move = Move(Coord(4, 3), Coord(4, 9))
+    assert is_legal_move(game, safe_move)
+
+
+def test_checkmate_detection_and_legal_move_generation() -> None:
+    board = Board(
+        {
+            Coord(4, 1): Piece(Side.RED, PieceType.KING),
+            Coord(4, 7): Piece(Side.RED, PieceType.ROOK),
+            Coord(3, 8): Piece(Side.RED, PieceType.ROOK),
+            Coord(6, 7): Piece(Side.RED, PieceType.HORSE),
+            Coord(6, 8): Piece(Side.RED, PieceType.PAWN),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.KING),
+        }
+    )
+    position = Position(board=board, side_to_move=Side.RED)
+    game = Game(position=position)
+
+    finishing_move = Move(Coord(6, 8), Coord(5, 8))
+    game.apply_move(finishing_move)
+
+    assert game.result is GameResult.RED_WIN
+    assert position.side_to_move is Side.BLACK
+    assert is_checkmate(position, Side.BLACK)
+    assert generate_legal_moves(position, Side.BLACK) == []

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,134 @@
+import pytest
+
+from xiangqi_core import (
+    Board,
+    Coord,
+    Move,
+    Piece,
+    PieceType,
+    Position,
+    Side,
+    is_pseudo_legal_move,
+)
+
+
+def test_rook_requires_clear_path() -> None:
+    board = Board({Coord(0, 0): Piece(Side.RED, PieceType.ROOK)})
+    position = Position(board=board, side_to_move=Side.RED)
+    assert is_pseudo_legal_move(position, Move(Coord(0, 0), Coord(0, 5)))
+
+    blocked_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.ROOK),
+            Coord(0, 3): Piece(Side.RED, PieceType.PAWN),
+        }
+    )
+    blocked_pos = Position(board=blocked_board, side_to_move=Side.RED)
+    assert not is_pseudo_legal_move(blocked_pos, Move(Coord(0, 0), Coord(0, 5)))
+
+
+def test_cannon_needs_screen_to_capture() -> None:
+    clear_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.CANNON),
+        }
+    )
+    clear_pos = Position(board=clear_board, side_to_move=Side.RED)
+    assert is_pseudo_legal_move(clear_pos, Move(Coord(0, 0), Coord(0, 5)))
+
+    capture_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.CANNON),
+            Coord(0, 1): Piece(Side.RED, PieceType.PAWN),
+            Coord(0, 3): Piece(Side.BLACK, PieceType.ROOK),
+        }
+    )
+    capture_pos = Position(board=capture_board, side_to_move=Side.RED)
+    assert is_pseudo_legal_move(capture_pos, Move(Coord(0, 0), Coord(0, 3)))
+
+    two_screens_board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.CANNON),
+            Coord(0, 1): Piece(Side.RED, PieceType.PAWN),
+            Coord(0, 2): Piece(Side.BLACK, PieceType.PAWN),
+            Coord(0, 3): Piece(Side.BLACK, PieceType.ROOK),
+        }
+    )
+    two_screens_pos = Position(board=two_screens_board, side_to_move=Side.RED)
+    assert not is_pseudo_legal_move(two_screens_pos, Move(Coord(0, 0), Coord(0, 3)))
+
+
+def test_horse_blocked_by_leg() -> None:
+    blocked_board = Board(
+        {
+            Coord(4, 4): Piece(Side.RED, PieceType.HORSE),
+            Coord(4, 5): Piece(Side.BLACK, PieceType.PAWN),
+        }
+    )
+    blocked_pos = Position(board=blocked_board, side_to_move=Side.RED)
+    assert not is_pseudo_legal_move(blocked_pos, Move(Coord(4, 4), Coord(5, 6)))
+
+    open_board = Board({Coord(4, 4): Piece(Side.RED, PieceType.HORSE)})
+    open_pos = Position(board=open_board, side_to_move=Side.RED)
+    assert is_pseudo_legal_move(open_pos, Move(Coord(4, 4), Coord(5, 6)))
+
+
+def test_elephant_and_advisor_restrictions() -> None:
+    elephant_board = Board({Coord(4, 4): Piece(Side.RED, PieceType.ELEPHANT)})
+    elephant_pos = Position(board=elephant_board, side_to_move=Side.RED)
+    assert not is_pseudo_legal_move(elephant_pos, Move(Coord(4, 4), Coord(2, 6)))
+
+    blocked_elephant_board = Board(
+        {
+            Coord(4, 4): Piece(Side.RED, PieceType.ELEPHANT),
+            Coord(3, 3): Piece(Side.BLACK, PieceType.PAWN),
+        }
+    )
+    blocked_elephant_pos = Position(board=blocked_elephant_board, side_to_move=Side.RED)
+    assert not is_pseudo_legal_move(blocked_elephant_pos, Move(Coord(4, 4), Coord(2, 2)))
+
+    advisor_board = Board({Coord(4, 1): Piece(Side.RED, PieceType.ADVISOR)})
+    advisor_pos = Position(board=advisor_board, side_to_move=Side.RED)
+    assert is_pseudo_legal_move(advisor_pos, Move(Coord(4, 1), Coord(5, 2)))
+    assert not is_pseudo_legal_move(advisor_pos, Move(Coord(4, 1), Coord(6, 3)))
+
+
+def test_king_stays_in_palace() -> None:
+    board = Board({Coord(4, 1): Piece(Side.RED, PieceType.KING)})
+    position = Position(board=board, side_to_move=Side.RED)
+
+    assert is_pseudo_legal_move(position, Move(Coord(4, 1), Coord(4, 2)))
+    assert not is_pseudo_legal_move(position, Move(Coord(4, 1), Coord(4, 3)))
+    assert not is_pseudo_legal_move(position, Move(Coord(4, 1), Coord(2, 1)))
+
+
+@pytest.mark.parametrize(
+    ("frm", "to", "expected"),
+    [
+        (Coord(4, 3), Coord(4, 4), True),
+        (Coord(4, 3), Coord(3, 3), False),
+        (Coord(4, 3), Coord(4, 2), False),
+        (Coord(4, 5), Coord(3, 5), True),
+        (Coord(4, 5), Coord(4, 4), False),
+    ],
+)
+def test_red_pawn_progression(frm: Coord, to: Coord, expected: bool) -> None:
+    board = Board({frm: Piece(Side.RED, PieceType.PAWN)})
+    position = Position(board=board, side_to_move=Side.RED)
+    assert is_pseudo_legal_move(position, Move(frm, to)) is expected
+
+
+@pytest.mark.parametrize(
+    ("frm", "to", "expected"),
+    [
+        (Coord(4, 6), Coord(4, 5), True),
+        (Coord(4, 6), Coord(5, 6), False),
+        (Coord(4, 6), Coord(4, 7), False),
+        (Coord(4, 4), Coord(5, 4), True),
+        (Coord(4, 4), Coord(4, 5), False),
+    ],
+)
+def test_black_pawn_progression(frm: Coord, to: Coord, expected: bool) -> None:
+    board = Board({frm: Piece(Side.BLACK, PieceType.PAWN)})
+    position = Position(board=board, side_to_move=Side.BLACK)
+    assert is_pseudo_legal_move(position, Move(frm, to)) is expected


### PR DESCRIPTION
## Summary
- add pseudo-legal move validation for all Xiangqi piece types and attack detection utilities
- implement full legality checking, checkmate detection, and a Game state machine with result tracking
- expand test suite with coverage for movement rules, attack detection, and checkmate scenarios

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694fc917ac088324905370bcbb837d2d)