### PR TITLE
Add minimal CLI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ A step-by-step Chinese Chess project built with vibe coding.
 
 ## Status
 🚧 In active development
+
+## CLI Demo
+A minimal interactive demo is available for manual exploration of the rules:
+
+```bash
+python -m xiangqi_cli_demo
+```

--- a/src/xiangqi_cli_demo.py
+++ b/src/xiangqi_cli_demo.py
@@ -1,0 +1,113 @@
+"""Minimal CLI demonstration for the Xiangqi core rules.
+
+The CLI is intentionally lightweight and keeps all state in-memory. It should
+remain separate from the core rules so the engine can stay UI-agnostic.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from xiangqi_core import (
+    Game,
+    GameResult,
+    Move,
+    Position,
+    Side,
+    XiangqiError,
+    is_in_check,
+)
+from xiangqi_core.board import Board
+from xiangqi_core.coord import Coord
+from xiangqi_core.piece import Piece
+from xiangqi_core.types import PieceType
+
+_PIECE_SYMBOLS = {
+    PieceType.KING: "k",
+    PieceType.ADVISOR: "a",
+    PieceType.ELEPHANT: "e",
+    PieceType.HORSE: "h",
+    PieceType.ROOK: "r",
+    PieceType.CANNON: "c",
+    PieceType.PAWN: "p",
+}
+
+
+def _piece_symbol(piece: Piece) -> str:
+    """Return a single-character symbol for ``piece``."""
+
+    symbol = _PIECE_SYMBOLS[piece.type]
+    return symbol.upper() if piece.side is Side.RED else symbol.lower()
+
+
+def render_board(position: Position) -> str:
+    """Render ``position`` as an ASCII board."""
+
+    header = "   a b c d e f g h i"
+    rows: List[str] = [header]
+    for y in range(9, -1, -1):
+        symbols: Iterable[str] = (
+            _piece_symbol(piece) if (piece := position.board.get(Coord(x, y))) else "."
+            for x in range(9)
+        )
+        rows.append(f"{y}  {' '.join(symbols)}")
+    rows.append(header)
+    return "\n".join(rows)
+
+
+def describe_status(game: Game) -> str:
+    """Summarize the side to move, check status, and result."""
+
+    side_label = "Red" if game.position.side_to_move is Side.RED else "Black"
+    parts = [f"Side to move: {side_label}"]
+
+    if game.result is not GameResult.ONGOING:
+        winner = "Red" if game.result is GameResult.RED_WIN else "Black"
+        parts.append(f"Game over — {winner} wins")
+        return " | ".join(parts)
+
+    if is_in_check(game.position, game.position.side_to_move):
+        parts.append(f"{side_label} is in check")
+
+    return " | ".join(parts)
+
+
+def _print_help() -> None:
+    print("Enter moves as four characters, e.g., e2e3")
+    print("Commands: 'exit' or 'quit' to leave, 'help' to show this message.")
+
+
+def _prompt() -> str:
+    return input("move> ").strip()
+
+
+def main() -> None:  # pragma: no cover - interactive wrapper
+    """Run the interactive CLI demo."""
+
+    game = Game()
+    print("Xiangqi CLI demo (from-to format, e.g., a0a1). Type 'help' for info.")
+    while True:
+        print(render_board(game.position))
+        print(describe_status(game))
+        if game.result is not GameResult.ONGOING:
+            break
+
+        command = _prompt()
+        lower = command.lower()
+        if lower in {"quit", "exit"}:
+            break
+        if lower == "help":
+            _print_help()
+            continue
+        if not command:
+            continue
+
+        try:
+            move = Move.from_str(command)
+            game.apply_move(move)
+        except XiangqiError as exc:
+            print(f"❌ {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    main()

--- a/tests/test_cli_demo.py
+++ b/tests/test_cli_demo.py
@@ -1,0 +1,44 @@
+import textwrap
+
+from xiangqi_cli_demo import describe_status, render_board
+from xiangqi_core import Game, GameResult, Position
+from xiangqi_core.board import Board
+from xiangqi_core.coord import Coord
+from xiangqi_core.piece import Piece
+from xiangqi_core.types import PieceType, Side
+
+
+def test_render_board_initial_position():
+    game = Game()
+
+    expected = textwrap.dedent(
+        """\
+           a b c d e f g h i
+        9  r h e a k a e h r
+        8  . . . . . . . . .
+        7  . c . . . . . c .
+        6  p . p . p . p . p
+        5  . . . . . . . . .
+        4  . . . . . . . . .
+        3  P . P . P . P . P
+        2  . C . . . . . C .
+        1  . . . . . . . . .
+        0  R H E A K A E H R
+           a b c d e f g h i"""
+    )
+
+    assert render_board(game.position) == expected
+
+
+def test_describe_status_includes_check_and_results():
+    board = Board()
+    board.place(Coord(4, 9), Piece(Side.BLACK, PieceType.KING))
+    board.place(Coord(0, 0), Piece(Side.RED, PieceType.KING))
+    board.place(Coord(4, 0), Piece(Side.RED, PieceType.ROOK))
+    position = Position(board=board, side_to_move=Side.BLACK)
+    game = Game(position=position)
+
+    assert describe_status(game) == "Side to move: Black | Black is in check"
+
+    game.result = GameResult.RED_WIN
+    assert describe_status(game) == "Side to move: Black | Game over — Red wins"


### PR DESCRIPTION
## Summary
- add a minimal interactive CLI demo for trying the core move engine manually
- render board state and surface side-to-move/check information for the demo loop
- document the demo entrypoint and cover board rendering/status helpers with tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694fd01e4d10832496825a50f91d38b5)