### PR TITLE
End game when king captured

### DIFF
--- a/src/xiangqi_core/game.py
+++ b/src/xiangqi_core/game.py
@@ -9,7 +9,7 @@ from xiangqi_core.board import Position, initial_position
 from xiangqi_core.errors import GameOverError, IllegalMoveError
 from xiangqi_core.legality import generate_legal_moves, is_checkmate, is_legal_move
 from xiangqi_core.move import Move
-from xiangqi_core.types import Side
+from xiangqi_core.types import PieceType, Side
 
 
 class GameResult(str, Enum):
@@ -37,9 +37,13 @@ class Game:
         if not is_legal_move(self, move):
             raise IllegalMoveError(f"Illegal move: {move.to_str()}")
 
-        self.position.board.move_piece(move)
+        captured = self.position.board.move_piece(move)
         self.history.append(move)
         self.position.side_to_move = self.position.side_to_move.opponent()
+
+        if captured is not None and captured.type is PieceType.KING:
+            self.result = GameResult.RED_WIN if captured.side is Side.BLACK else GameResult.BLACK_WIN
+            return
 
         opponent = self.position.side_to_move
         if is_checkmate(self.position, opponent):

--- a/tests/test_legality.py
+++ b/tests/test_legality.py
@@ -1,7 +1,10 @@
+import pytest
+
 from xiangqi_core import (
     Board,
     Coord,
     Game,
+    GameOverError,
     GameResult,
     Move,
     Piece,
@@ -54,3 +57,22 @@ def test_checkmate_detection_and_legal_move_generation() -> None:
     assert position.side_to_move is Side.BLACK
     assert is_checkmate(position, Side.BLACK)
     assert generate_legal_moves(position, Side.BLACK) == []
+
+
+def test_game_ends_when_king_is_captured() -> None:
+    board = Board(
+        {
+            Coord(0, 0): Piece(Side.RED, PieceType.KING),
+            Coord(4, 5): Piece(Side.RED, PieceType.ROOK),
+            Coord(4, 9): Piece(Side.BLACK, PieceType.KING),
+        }
+    )
+    position = Position(board=board, side_to_move=Side.RED)
+    game = Game(position=position)
+
+    winning_move = Move(Coord(4, 5), Coord(4, 9))
+    game.apply_move(winning_move)
+
+    assert game.result is GameResult.RED_WIN
+    with pytest.raises(GameOverError):
+        game.apply_move(Move(Coord(0, 0), Coord(0, 1)))


### PR DESCRIPTION
## Summary
- declare the moving side the winner immediately after capturing the opposing king
- add a regression test to ensure play stops once a king is taken

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695773e0992883249c04edbc995c13df)